### PR TITLE
fix(VDatePicker): scroll not honoring min and max tableDate

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -19,6 +19,7 @@ import {
   createItemTypeListeners,
   createNativeLocaleFormatter,
   pad,
+  sanitizeDateString,
 } from './util'
 
 // Types
@@ -40,13 +41,6 @@ type DatePickerValue = string | string[] | undefined
 interface Formatters {
   year: DatePickerFormatter
   titleDate: DatePickerFormatter | DatePickerMultipleFormatter
-}
-
-// Adds leading zero to month/day if necessary, returns 'YYYY' if type = 'year',
-// 'YYYY-MM' if 'month' and 'YYYY-MM-DD' if 'date'
-function sanitizeDateString (dateString: string, type: 'date' | 'month' | 'year'): string {
-  const [year, month = 1, date = 1] = dateString.split('-')
-  return `${year}-${pad(month)}-${pad(date)}`.substr(0, { date: 10, month: 7, year: 4 }[type])
 }
 
 export default mixins(

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerDateTable.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerDateTable.spec.ts
@@ -252,6 +252,38 @@ describe('VDatePickerDateTable.ts', () => {
     expect(tableDate).not.toHaveBeenCalled()
   })
 
+  it('should not emit tableDate event when scrollable but tableDate less than min', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        tableDate: '2005-05',
+        scrollable: true,
+        min: '2005-05',
+      },
+    })
+
+    const tableDate = jest.fn()
+    wrapper.vm.$on('update:table-date', tableDate)
+
+    wrapper.trigger('wheel', { deltaY: -50 })
+    expect(tableDate).not.toHaveBeenCalled()
+  })
+
+  it('should emit tableDate event when scrollable and tableDate greater than min', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        tableDate: '2005-05',
+        scrollable: true,
+        min: '2005-03',
+      },
+    })
+
+    const tableDate = jest.fn()
+    wrapper.vm.$on('update:table-date', tableDate)
+
+    wrapper.trigger('wheel', { deltaY: -50 })
+    expect(tableDate).toHaveBeenCalledWith('2005-04')
+  })
+
   // TODO
   it.skip('should emit tableDate event when swiped', () => {
     const wrapper = mountFunction({

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerMonthTable.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerMonthTable.spec.ts
@@ -142,6 +142,38 @@ describe('VDatePickerMonthTable.ts', () => {
     expect(tableDate).not.toHaveBeenCalled()
   })
 
+  it('should not emit tableDate event when scrollable but tableDate less than min', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        tableDate: '2005',
+        scrollable: true,
+        min: '2005',
+      },
+    })
+
+    const tableDate = jest.fn()
+    wrapper.vm.$on('update:table-date', tableDate)
+
+    wrapper.trigger('wheel', { deltaY: -50 })
+    expect(tableDate).not.toHaveBeenCalled()
+  })
+
+  it('should emit tableDate event when scrollable and tableDate greater than min', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        tableDate: '2005',
+        scrollable: true,
+        min: '2003',
+      },
+    })
+
+    const tableDate = jest.fn()
+    wrapper.vm.$on('update:table-date', tableDate)
+
+    wrapper.trigger('wheel', { deltaY: -50 })
+    expect(tableDate).toHaveBeenCalledWith('2004')
+  })
+
   // TODO
   it.skip('should emit tableDate event when swiped', () => {
     const wrapper = mountFunction({

--- a/packages/vuetify/src/components/VDatePicker/util/__tests__/sanitizeDateString.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/__tests__/sanitizeDateString.spec.ts
@@ -1,0 +1,10 @@
+import sanitizeDateString from '../sanitizeDateString'
+
+describe('VDatePicker/util/sanitizeDateString.ts', () => {
+  it('should sanitize date string based upon type', () => {
+    expect(sanitizeDateString('2000-01-02T14:48:00.000Z', 'date')).toBe('2000-01-02')
+    expect(sanitizeDateString('2000-01-02T14:48:00.000Z', 'month')).toBe('2000-01')
+    expect(sanitizeDateString('2000-01-02T14:48:00.000Z', 'year')).toBe('2000')
+    expect(sanitizeDateString('2000-1-2', 'date')).toBe('2000-01-02')
+  })
+})

--- a/packages/vuetify/src/components/VDatePicker/util/index.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/index.ts
@@ -4,6 +4,7 @@ import {
 } from './eventHelpers'
 import createNativeLocaleFormatter from './createNativeLocaleFormatter'
 import monthChange from './monthChange'
+import sanitizeDateString from './sanitizeDateString'
 import pad from './pad'
 
 export {
@@ -11,5 +12,6 @@ export {
   createItemTypeNativeListeners,
   createNativeLocaleFormatter,
   monthChange,
+  sanitizeDateString,
   pad,
 }

--- a/packages/vuetify/src/components/VDatePicker/util/sanitizeDateString.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/sanitizeDateString.ts
@@ -1,0 +1,8 @@
+// Adds leading zero to month/day if necessary, returns 'YYYY' if type = 'year',
+// 'YYYY-MM' if 'month' and 'YYYY-MM-DD' if 'date'
+import pad from './pad'
+
+export default (dateString: string, type: 'date' | 'month' | 'year'): string => {
+  const [year, month = 1, date = 1] = dateString.split('-')
+  return `${year}-${pad(month)}-${pad(date)}`.substr(0, { date: 10, month: 7, year: 4 }[type])
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Honoring Min and Max date value for Scrolling of VDatePicker .
Added checks to check if a valid scroll is made (i.e tableDate is between min and max date both inclusive) before triggering update:table-date event
fixes #12856

## Motivation and Context
Done to Fix #12856
To not perform scroll beyond min and max date

## How Has This Been Tested?
1. UTs have been added
2. Visually via Playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-date-picker
      :min="'2020-12-29T22:59:42+0000'"
      :max="'2021-01-01T22:59:42+0000'"
      range
      scrollable
    >
    </v-date-picker>
    <v-date-picker
      type="month"
      :min="'2020-12-29T22:59:42+0000'"
      :max="'2020-12-31T22:59:42+0000'"
      range
      scrollable
    >
    </v-date-picker>
    <v-date-picker
      range
      scrollable
    >
    </v-date-picker>
  </v-container>
</template>

<script>
  export default {
    data: () => {
      return {}
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
