### PR TITLE
fix(VTextField): legend position not aligned with reverse prop

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -371,6 +371,9 @@ export default baseMixins.extend<options>().extend({
         style: {
           width: !this.isSingle ? convertToUnit(width) : undefined,
         },
+        attrs: {
+          align: this.reverse ? 'right' : 'left',
+        },
       }, [span])
     },
     genInput () {

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -871,4 +871,27 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     const input = wrapper.find('input')
     expect(input.element.value).toBe('-0')
   })
+
+  it('should keep legend left by default', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        label: 'foo',
+        outlined: true,
+      },
+    })
+    const legend = wrapper.find('legend')
+    expect(legend.attributes('align')).toBe('left')
+  })
+
+  it('should move the legend right on reverse', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        label: 'foo',
+        reverse: true,
+        outlined: true,
+      },
+    })
+    const legend = wrapper.find('legend')
+    expect(legend.attributes('align')).toBe('right')
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Legend position was not aligned with the reverse prop that reverses the label position. So when the value of the reverse prop is true the legend should move right
fixes #10798

## Motivation and Context
Done to Fix #10798

## How Has This Been Tested?
1. Visually via playground on Chrome, Edge and Morzilla
2. UTs have be added to test legend alignment that is by default left and right when reversed

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field label="Label" outlined reverse></v-text-field>
    <v-text-field label="Label" outlined></v-text-field>
  </v-container>
</template>

<script>
  export default {
    data: () => {
      return {}
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
